### PR TITLE
Fix rebar3 release

### DIFF
--- a/src/rebar_mix.erl
+++ b/src/rebar_mix.erl
@@ -7,4 +7,4 @@ init(State) ->
     {ok, State1} = rebar_mix_hook:init(State),
     {ok, State2} = rebar_mix_elixir_finder_hook:init(State1),
     State3 = rebar_state:add_project_builder(State2, mix, rebar_mix_builder),
-    {ok, State3}.
+    rebar_mix_elixir_finder_hook:process_elixir_lib_paths(State3).

--- a/src/rebar_mix_builder.erl
+++ b/src/rebar_mix_builder.erl
@@ -1,11 +1,12 @@
 -module(rebar_mix_builder).
 
 -export([build/1,
-         format_error/1]).
+         format_error/1,
+         sh/2]).
 
 build(AppInfo) ->
     AppDir = rebar_app_info:dir(AppInfo),
-    case rebar_utils:sh("elixir -pa \"../*/ebin\" -S mix compile --no-load-deps "
+    case sh("elixir -pa \"../*/ebin\" -S mix compile --no-load-deps "
                         "--no-deps-check --no-protocol-consolidation",
                         [{cd, AppDir},
                          {return_on_error, true},
@@ -27,3 +28,6 @@ format_error({mix_compile_failed, Name, _Error}) ->
     io_lib:format("Failed to compile application ~ts with mix", [Name]);
 format_error(Reason) ->
     io_lib:format("~p", Reason).
+
+sh(Command, Options) ->
+    rebar_utils:sh(Command, [{env, [{"ERL_FLAGS", ""}]} | Options]).

--- a/src/rebar_mix_elixir_finder_hook.erl
+++ b/src/rebar_mix_elixir_finder_hook.erl
@@ -36,7 +36,7 @@ do(State) ->
             {ok, State};
         false ->
             %% ask elixir to print it's core libs
-            case rebar_utils:sh(?ELIXIR_CMD, [{return_on_error, true}, {use_stdout, false}]) of
+            case rebar_mix_builder:sh(?ELIXIR_CMD, [{return_on_error, true}, {use_stdout, false}]) of
                 {error, {127, _}} ->
                     {error, {?MODULE, elixir_not_found}};
                 {error, {_Code, _Error}} ->

--- a/src/rebar_mix_hook.erl
+++ b/src/rebar_mix_hook.erl
@@ -44,12 +44,13 @@ do(State) ->
     %% in order to not require figuring out where Elixir lives we
     %% shell out to elixir to run an elixir script. so the only
     %% requirement is that elixir is in the path.
-    case rebar_utils:sh("elixir rebar_mix_protocol_consolidation.exs",
+    case rebar_mix_builder:sh("elixir rebar_mix_protocol_consolidation.exs",
                         [{cd, ScriptDir},
                          {return_on_error, true},
                          {use_stdout, true},
                          {env, [{"REBAR_DEPS_EBIN", EbinDirsString},
-                                {"REBAR_PROTOCOLS_OUTDIR", OutDir}]}]) of
+                                {"REBAR_PROTOCOLS_OUTDIR", OutDir},
+                                {"ERL_FLAGS", ""}]}]) of
         {error, {127, _}} ->
             {error, {?MODULE, elixir_not_found}};
         {error, {_Code, _Error}} ->


### PR DESCRIPTION
`release` build under rebar3 does not process any provider hooks, and hence some configuration like the following would not call rebar_mix provider to be able to inject elixir libraries.

{provider_hooks, [
    {pre,  [{compile, {mix, find_elixir_libs}}]}, => callbacks during 'compile' phase get called
    {pre,  [{release, {mix, find_elixir_libs}}]}  => This will not callback find_elixir_libs
]}.

Given this, `relx` configuration in `rebar_state` needs to be updated with Elixir lib_dirs. This can be done from `rebar_mix` module as part of init callback. This solution does that.