### PR TITLE
Update protocol consolidation

### DIFF
--- a/src/rebar_mix_protocol_consolidation.exs
+++ b/src/rebar_mix_protocol_consolidation.exs
@@ -1,6 +1,7 @@
 # rebar3 provider sets this to all deps of the project being built
 paths = String.split(System.get_env("REBAR_DEPS_EBIN"), ":")
 out_dir = System.get_env("REBAR_PROTOCOLS_OUTDIR")
+File.mkdir_p!(out_dir)
 
 # For protocol consolidation run the following script
 # paths is a list of paths to dependency ebin directory
@@ -10,6 +11,7 @@ Enum.each(paths, fn path ->
     impls = Protocol.extract_impls(protocol, paths)
     :code.purge(protocol)
     :code.delete(protocol)
+    File.cd!(path)
     IO.puts "Consolidating #{length(impls)} implementations of protocol #{protocol}"
     {:ok, beam} = Protocol.consolidate(protocol, impls)
     File.write!(Path.join(out_dir, "#{protocol}.beam"), beam)


### PR DESCRIPTION
 - ensure _build/<env>/consolidated exists before we attempt to write to
   said path
 - change directory to the ebin of the dependency under _build/<env>/... per
   Protocol and/or system expectations