### PR TITLE
fix consolidation when protocols are scattered

### DIFF
--- a/src/rebar_mix_protocol_consolidation.exs
+++ b/src/rebar_mix_protocol_consolidation.exs
@@ -3,6 +3,12 @@ paths = String.split(System.get_env("REBAR_DEPS_EBIN", ""), ":")
 out_dir = System.get_env("REBAR_PROTOCOLS_OUTDIR", "")
 File.mkdir_p!(out_dir)
 
+for path <- paths do
+  path
+  |> to_charlist()
+  |> :code.add_path()
+end
+
 # For protocol consolidation run the following script
 # paths is a list of paths to dependency ebin directory
 # output is the output directory for the compiled protocol beam files


### PR DESCRIPTION
When there is an Elixir dependency defining a protocol, and another
dependency implementing it, we need all the beam file paths added when
doing protocol consolidation, otherwise the process fails.

This simple change adds the missing paths before consolidation begins.