### PR TITLE
fix pattern matching on resized tuple

### DIFF
--- a/src/rebar_mix_utils.erl
+++ b/src/rebar_mix_utils.erl
@@ -65,7 +65,9 @@ create_rebar_lock_from_mix(AppDir, Deps) ->
   lists:foldl(
     fun(AppLock, Locks) ->
         case AppLock of
-          {Name, {hex, App, Version, _, _, _, _}} ->
+          {Name, Hex} when element(1, Hex) == hex ->
+            App = element(2, Hex),
+            Version = element(3, Hex),
             case lists:member(to_string(Name), Deps) of
               true ->
                 Locks ++ [{to_binary(Name), {iex_dep, to_binary(App), Version}, 0}];


### PR DESCRIPTION
The original pattern `{hex, App, Version, _, _, _, _}` changed to `{hex, App, Version, _, _, _, _, _}` with my rebar version.  (That is, one more underscore in the pattern.)  This change accepts any tuple size flagged by the atom `hex` and gets the `App` and `Version` values from the 2nd and 3rd positions in the tuple.  This works with the old and new rebar tupple sizes, and is also immune to further added fields.